### PR TITLE
Fixed: Must copy CPRange before altering its content as we can’t change callers CPRange

### DIFF
--- a/CPTextView/Frameworks/TextView/CPTextStorage.j
+++ b/CPTextView/Frameworks/TextView/CPTextStorage.j
@@ -206,24 +206,26 @@ CPKernAttributeName = @"CPKernAttributeName";
 
 - (void)edited:(unsigned)editedMask range:(CPRange)aRange changeInLength:(int)lengthChange
 {
+    var copyRange = CPMakeRangeCopy(aRange);
+
     if (_editCount == 0) /* used outside a beginEditing/endEditing */
     {
         _editedMask = editedMask;
         _changeInLength = lengthChange;
-        aRange.length += lengthChange;
-        _editedRange = aRange;
+        copyRange.length += lengthChange;
+        _editedRange = copyRange;
         [self processEditing];
     }
     else
     {
         _editedMask |= editedMask;
         _changeInLength += lengthChange;
-        aRange.length += lengthChange;
+        copyRange.length += lengthChange;
 
         if (_editedRange.location == CPNotFound)
-            _editedRange = aRange;
+            _editedRange = copyRange;
         else
-            _editedRange = CPUnionRange(_editedRange,aRange);
+            _editedRange = CPUnionRange(_editedRange,copyRange);
     }
 }
 


### PR DESCRIPTION
When doing for example ```removeAttributes:atRange:``` the provided range will be altered as it is not copied inside the ```CPTextStorage```